### PR TITLE
Update JupyterLite to 0.6.4

### DIFF
--- a/packages/jupyterlite/README.md
+++ b/packages/jupyterlite/README.md
@@ -86,8 +86,9 @@ Downloads dataset(s) by HID, ID, or regex pattern. Saves them to Pyodide's virtu
 
 ```python
 await get(3)                          # by HID
-await get("some_id", identifier_type="id")
-await get("myfile.*", identifier_type="regex")
+await get("some_id", "id")
+await get("myfile.*", "regex")
+await get("mytag", "tag")
 ```
 
 ---

--- a/packages/jupyterlite/gxy/gxy/__init__.py
+++ b/packages/jupyterlite/gxy/gxy/__init__.py
@@ -200,7 +200,10 @@ async def put(name, output=None, ext="auto", dbkey="?", history_id=None):
     xhr.open("POST", get_api("/api/tools/fetch"))
     xhr.send(form)
     response = await future
-    return response.responseText
+    try:
+        return json.loads(response.responseText)
+    except Exception:
+        return response.responseText
 
 
 def _find_matching_ids(history_datasets, list_of_regex_patterns, identifier_type='hid'):
@@ -226,7 +229,7 @@ def _find_matching_ids(history_datasets, list_of_regex_patterns, identifier_type
         fid = dataset["id"]
         fhid = dataset["hid"]
         for pat in patterns:
-            if pat.match(fname):
+            if pat.search(fname):
                 print(f"🔍 Matched pattern on item {fhid} ({fid}): '{fname}'")
                 matching_ids.append(fhid if identifier_type == "hid" else fid)
     return list(set(matching_ids))

--- a/packages/jupyterlite/gxy/gxy/__init__.py
+++ b/packages/jupyterlite/gxy/gxy/__init__.py
@@ -61,7 +61,7 @@ async def get(datasets_identifiers, identifier_type="hid", history_id=None, retr
     datatypes_all = []
 
     # backend vs client filtered results
-    if filter_by_api(datasets_identifiers, identifier_type):
+    if _is_api_filter(datasets_identifiers, identifier_type):
         datasets = history_datasets
     else:
         # convert to list
@@ -126,7 +126,7 @@ async def get_history(history_id=None, datasets_identifiers=None, identifier_typ
 
     # use backend filtering if single identifer from map is provided
     query = ""
-    if filter_by_api(datasets_identifiers, identifier_type):
+    if _is_api_filter(datasets_identifiers, identifier_type):
         query = f"?v=dev&q={IDENTIFIER_TYPES[identifier_type]}&qv={datasets_identifiers}"
     url = get_api(f"/api/histories/{history_id}/contents{query}")
 
@@ -268,7 +268,7 @@ def _find_matching_datasets(history_datasets, list_of_regex_patterns):
     return list(matching_datasets.values())
 
 
-def filter_by_api(datasets_identifiers, identifier_type):
+def _is_api_filter(datasets_identifiers, identifier_type):
     return identifier_type in IDENTIFIER_TYPES and not isinstance(datasets_identifiers, list) and datasets_identifiers
 
 __all__ = ["api", "get", "get_environment", "get_history", "get_history_id", "put"]

--- a/packages/jupyterlite/gxy/gxy/__init__.py
+++ b/packages/jupyterlite/gxy/gxy/__init__.py
@@ -50,10 +50,10 @@ async def get(datasets_identifiers, identifier_type="hid", history_id=None, retr
     """
 
     # download datasets by id without filtering
+    datasets = []
     if identifier_type == "id":
         if not isinstance(datasets_identifiers, list):
             datasets_identifiers = [datasets_identifiers]
-        datasets = []
         for identifers in datasets_identifiers:
             ds = await api(f"/api/datasets/{identifers}")
             datasets.append(ds)
@@ -74,7 +74,6 @@ async def get(datasets_identifiers, identifier_type="hid", history_id=None, retr
                 datasets = _find_matching_datasets(history_datasets, datasets_identifiers)
             else:
                 # match attributes
-                datasets = []
                 for ds in history_datasets:
                     if identifier_type not in ds:
                         raise Exception(f"Unavailable dataset identifier type: {identifier_type}")

--- a/packages/jupyterlite/gxy/gxy/__init__.py
+++ b/packages/jupyterlite/gxy/gxy/__init__.py
@@ -39,6 +39,44 @@ async def api(endpoint, method="GET", data=None):
         return text
 
 
+async def download_dataset(dataset):
+    """
+    Given a dataset id, its content is downloaded from Galaxy and stored in Pyodide’s virtual filesystem.
+
+    Args:
+        dataset_id: String of dataset identifier
+
+    Returns:
+        String path of stored file
+    """
+    dataset_id = dataset['id']
+    history_id = dataset['history_id']
+    history_content_type = dataset["history_content_type"]
+    path = f"/{history_id}/{dataset_id}"
+
+    # download only if not already written
+    if not os.path.exists(path):
+        if history_content_type == "dataset":
+            url = get_api(f"/api/datasets/{dataset_id}/display")
+            response = await fetch(url)
+            if not response.ok:
+                raise Exception(f"Failed to fetch dataset {dataset_id}: {response.status}")
+            content_type = response.headers.get("Content-Type", "")
+            if content_type.startswith("text/"):
+                content = await response.text()
+                with open(path, "w") as f:
+                    f.write(content)
+            else:
+                buffer = await response.arrayBuffer()
+                data = bytearray(buffer.to_py())
+                with open(path, "wb") as f:
+                    f.write(data)
+        elif history_content_type == "dataset_collection":
+            raise Exception("Not implemented.")
+
+    return path
+
+
 async def get(datasets_identifiers, identifier_type="hid", history_id=None, retrieve_datatype=False):
     """
     Downloads dataset(s) from the current Galaxy history.
@@ -81,7 +119,7 @@ async def get(datasets_identifiers, identifier_type="hid", history_id=None, retr
 
     # download filtered datasets
     for ds in datasets:
-        path = await _download_dataset(ds)
+        path = await download_dataset(ds)
         file_path_all.append(path)
         if retrieve_datatype:
             datatypes_all.append({dataset_id: ds["extension"]})
@@ -202,44 +240,6 @@ async def put(name, output=None, ext="auto", dbkey="?", history_id=None):
         return json.loads(response.responseText)
     except Exception:
         return response.responseText
-
-
-async def _download_dataset(dataset):
-    """
-    Given a dataset object, its content is downloaded from Galaxy and stored in Pyodide’s virtual filesystem.
-
-    Args:
-        dataset: Object of dataset
-
-    Returns:
-        String path of stored file
-    """
-    dataset_id = dataset['id']
-    history_id = dataset['history_id']
-    history_content_type = dataset["history_content_type"]
-    path = f"/{history_id}/{dataset_id}"
-
-    # download only if not already written
-    if not os.path.exists(path):
-        if history_content_type == "dataset":
-            url = get_api(f"/api/datasets/{dataset_id}/display")
-            response = await fetch(url)
-            if not response.ok:
-                raise Exception(f"Failed to fetch dataset {dataset_id}: {response.status}")
-            content_type = response.headers.get("Content-Type", "")
-            if content_type.startswith("text/"):
-                content = await response.text()
-                with open(path, "w") as f:
-                    f.write(content)
-            else:
-                buffer = await response.arrayBuffer()
-                data = bytearray(buffer.to_py())
-                with open(path, "wb") as f:
-                    f.write(data)
-        elif history_content_type == "dataset_collection":
-            raise Exception("Not implemented.")
-
-    return path
 
 
 def _find_matching_datasets(history_datasets, list_of_regex_patterns):

--- a/packages/jupyterlite/package.json
+++ b/packages/jupyterlite/package.json
@@ -1,8 +1,10 @@
 {
     "name": "@galaxyproject/jupyterlite",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "type": "module",
-    "files": ["static"],
+    "files": [
+        "static"
+    ],
     "scripts": {
         "build": "webpack && npm run build:jupyter && npm run build:gxy && npm run build:extension && npm run build:patch && npm run build:index",
         "build:extension": "node install-extension.js",
@@ -23,7 +25,9 @@
         "ts-loader": "^9.5.0",
         "typescript": "^5.4.2",
         "webpack": "^5.89.0",
-        "webpack-cli": "^5.1.4"
+        "webpack-cli": "^5.1.4",
+        "@jupyterlab/application": "^4.0.0",
+        "@jupyterlab/apputils": "^4.0.0"
     },
     "dependencies": {
         "node-fetch": "^3.3.2"

--- a/packages/jupyterlite/package.json
+++ b/packages/jupyterlite/package.json
@@ -13,8 +13,8 @@
         "build:jupyter": "jupyter lite build --output-dir static/dist/_output --config static/dist/_output/jupyter-lite.json",
         "build:patch": "node patch-config.js",
         "dev": "jupyter lite serve --output-dir static/dist/_output --config static/dist/_output/jupyter-lite.json",
-        "prettier": "prettier --write 'package.json' '*.js' 'src/*.js' 'src/*.ts'",
-        "test": "npx playwright test --headed"
+        "prettier": "prettier --write 'package.json' '*.js' '*.ts' 'src/*.js' 'src/*.ts'",
+        "test": "npx playwright test"
     },
     "devDependencies": {
         "@playwright/test": "^1.52.0",

--- a/packages/jupyterlite/package.json
+++ b/packages/jupyterlite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@galaxyproject/jupyterlite",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "type": "module",
     "files": [
         "static"

--- a/packages/jupyterlite/playwright.config.ts
+++ b/packages/jupyterlite/playwright.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  timeout: 120000, // 120 seconds per test
-  use: {
-    headless: false, // run headed
-  },
+    timeout: 120000, // 120 seconds per test
+    use: {
+        headless: false, // run headed
+    },
 });

--- a/packages/jupyterlite/playwright.config.ts
+++ b/packages/jupyterlite/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  timeout: 120000, // 120 seconds per test
+  use: {
+    headless: false, // run headed
+  },
+});

--- a/packages/jupyterlite/public/jupyterlite.xml
+++ b/packages/jupyterlite/public/jupyterlite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="JupyterLite" embeddable="true">
+<visualization name="JupyterLite" creatable="true" embeddable="true">
     <description>Pyodide-based Jupyter Notebooks</description>
     <data_sources>
         <data_source>

--- a/packages/jupyterlite/public/jupyterlite.xml
+++ b/packages/jupyterlite/public/jupyterlite.xml
@@ -11,9 +11,6 @@
     <params>
         <param required="true">dataset_id</param>
     </params>
-    <requirements>
-        <requirement type="npm" version="0.0.10" package="@galaxyproject/jupyterlite"/>
-    </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" />
     <tests>
         <test>

--- a/packages/jupyterlite/public/jupyterlite.xml
+++ b/packages/jupyterlite/public/jupyterlite.xml
@@ -63,6 +63,9 @@ await gxy.api("/api/histories", method="GET")
 # Download a dataset by HID into the virtual filesystem
 await gxy.get(3)
 
+# Download datasets by tag into the virtual filesystem
+await gxy.get("my-tag", "tag")
+
 # Upload a local file to the associated Galaxy history (renamed to "newname.txt")
 await gxy.put("output.txt", "newname.txt")
 

--- a/packages/jupyterlite/pyodide.txt
+++ b/packages/jupyterlite/pyodide.txt
@@ -1,3 +1,3 @@
-plotly==6.0.1
+plotly==6.3.0
 nbformat==5.10.4
-typing_extensions==4.13.2
+typing_extensions==4.15.0

--- a/packages/jupyterlite/requirements.txt
+++ b/packages/jupyterlite/requirements.txt
@@ -1,4 +1,4 @@
-build==1.2.2.post1
-jupyterlite==0.5.1
-jupyterlite-pyodide-kernel==0.5.2
+build==1.3.0
+jupyterlite==0.6.4
+jupyterlite-pyodide-kernel==0.6.1
 jupyterlab-server==2.27.3

--- a/packages/jupyterlite/requirements.txt
+++ b/packages/jupyterlite/requirements.txt
@@ -1,4 +1,4 @@
-build==1.3.0
+build==1.2.2.post1
 jupyterlite==0.6.4
 jupyterlite-pyodide-kernel==0.6.1
 jupyterlab-server==2.27.3

--- a/packages/jupyterlite/src/extension.ts
+++ b/packages/jupyterlite/src/extension.ts
@@ -1,4 +1,4 @@
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from "@jupyterlab/application";
+import type { JupyterFrontEnd, JupyterFrontEndPlugin } from "@jupyterlab/application";
 import { InputDialog } from "@jupyterlab/apputils";
 import axios from "axios";
 
@@ -98,7 +98,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
                 }
 
                 // open and save notebooks
-                app.commands.commandExecuted.connect(async (_, args) => {
+                app.commands.commandExecuted.connect(async (_: any, args: any) => {
                     if (args.id === "docmanager:open") {
                         args.result.then(async (widget: any) => {
                             const model = widget?.content?.model;
@@ -121,7 +121,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
                                 let name = path.split("/").pop() || getTimestamp();
                                 const input = await InputDialog.getText({
                                     title: "💾 Save to Galaxy?",
-                                    label: `Provide a name to save to source history:`,
+                                    label: "Provide a name to save to source history:",
                                     text: name,
                                 });
                                 if (input.button.accept && input.value) {

--- a/packages/jupyterlite/static/jupyterlite.xml
+++ b/packages/jupyterlite/static/jupyterlite.xml
@@ -60,6 +60,9 @@ await gxy.api("/api/histories", method="GET")
 # Download a dataset by HID into the virtual filesystem
 await gxy.get(3)
 
+# Download datasets by tag into the virtual filesystem
+await gxy.get("my-tag", "tag")
+
 # Upload a local file to the associated Galaxy history (renamed to "newname.txt")
 await gxy.put("output.txt", "newname.txt")
 

--- a/packages/jupyterlite/static/jupyterlite.xml
+++ b/packages/jupyterlite/static/jupyterlite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="JupyterLite" embeddable="true">
+<visualization name="JupyterLite" creatable="true" embeddable="true">
     <description>Pyodide-based Jupyter Notebooks</description>
     <data_sources>
         <data_source>

--- a/packages/jupyterlite/test.spec.js
+++ b/packages/jupyterlite/test.spec.js
@@ -139,6 +139,10 @@ test("Create new Python notebook from menu and run a cell", async ({ page }) => 
     await executeNext(page, ["import gxy", "print(await gxy.get('test', 'tag'))"]);
     await checkOutputArea(page, 6, "/history_id/dataset_1");
 
+    // test gxy client id filter
+    await executeNext(page, ["import gxy", "print(await gxy.get('dataset_0', 'id'))"]);
+    await checkOutputArea(page, 7, "/history_id/dataset_0");
+
     // test plotly, numpy and pandas
     const plotlyCode = [
         "import plotly.express as px",

--- a/packages/jupyterlite/test.spec.js
+++ b/packages/jupyterlite/test.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
-const DATASET_0 = { id: "dataset_0", hid: 99, history_content_type: "dataset", history_id: "history_id" };
-const DATASET_1 = { id: "dataset_1", hid: 98, history_content_type: "dataset", history_id: "history_id" };
+const DATASET_0 = { id: "dataset_0", hid: 99, history_content_type: "dataset", history_id: "history_id", name: "notebook" };
+const DATASET_1 = { id: "dataset_1", hid: 98, history_content_type: "dataset", history_id: "history_id", name: "sample" };
 
 async function createNotebook(page) {
     await page.waitForSelector("#jp-MainMenu");
@@ -122,6 +122,10 @@ test("Create new Python notebook from menu and run a cell", async ({ page }) => 
     // test gxy backend filter
     await executeNext(page, ["import gxy", "print(await gxy.get(98))"]);
     await checkOutputArea(page, 4, "/history_id/dataset_1");
+
+    // test gxy client regex filter
+    await executeNext(page, ["import gxy", "print(await gxy.get('boo', 'regex'))"]);
+    await checkOutputArea(page, 5, "/history_id/dataset_0");
 
     // test plotly, numpy and pandas
     const plotlyCode = [


### PR DESCRIPTION
Update JupyterLite version to latest, add test cases, and improve `gxy.get()` performance on large histories by using Galaxy API dataset filtering where possible. Users can now also call `gxy.get("MYTAG", "tag")` to download all datasets containing a specific tag (feature request by @nekrut).