### PR TITLE
[polaris] Cap traversal fetch requests at 25

### DIFF
--- a/packages/polaris/package.json
+++ b/packages/polaris/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@galaxyproject/polaris",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "type": "module",
     "license": "MIT",
     "files": [

--- a/packages/polaris/package.json
+++ b/packages/polaris/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@galaxyproject/polaris",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "type": "module",
     "license": "MIT",
     "files": [

--- a/packages/polaris/polaris/polaris/modules/handlers/traverse.py
+++ b/packages/polaris/polaris/polaris/modules/handlers/traverse.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 # Default limits
 DEFAULT_MAX_DEPTH = 20
-DEFAULT_MAX_PER_LEVEL = 20
+DEFAULT_MAX_PER_LEVEL = 10
 DEFAULT_DELAY = 0.5  # Delay between fetches in seconds
 
 # Hard limit on total API calls to prevent overload

--- a/packages/polaris/polaris/tests/handlers/test_traverse.py
+++ b/packages/polaris/polaris/tests/handlers/test_traverse.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from polaris.modules.constants import ErrorCode
-from polaris.modules.handlers.traverse import TraverseHandler
+from polaris.modules.handlers.traverse import TraverseHandler, MAX_FETCHES
 
 
 @pytest.fixture
@@ -872,3 +872,158 @@ class TestDedupField:
         # Datasets: d_out (seed, not counted) + 3 from inputs (limited by max_per_level)
         # Total should be 4 (seed + 3 fetched)
         assert len(datasets) == 4, "Should have seed + 3 fetched datasets (limited by max_per_level)"
+
+
+class TestMaxFetchesLimit:
+    """Tests for MAX_FETCHES hard limit on total API calls."""
+
+    @pytest.fixture
+    def handler(self):
+        return TraverseHandler()
+
+    @pytest.fixture
+    def mock_registry(self):
+        registry = MagicMock()
+        registry.call_api = AsyncMock()
+        return registry
+
+    @pytest.fixture
+    def mock_runner(self):
+        runner = MagicMock()
+        runner.state = {}
+
+        def resolve(value, ctx):
+            if value is None:
+                return None
+            if isinstance(value, dict) and "$ref" in value:
+                ref = value["$ref"]
+                parts = ref.split(".")
+                obj = ctx
+                for part in parts:
+                    if isinstance(obj, dict):
+                        obj = obj.get(part)
+                    else:
+                        return None
+                return obj
+            return value
+
+        runner.resolver = MagicMock()
+        runner.resolver.resolve = resolve
+        runner.resolver.apply_emit = MagicMock()
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_max_fetches_limits_total_api_calls(
+        self, handler, mock_registry, mock_runner
+    ):
+        """
+        MAX_FETCHES limits total API calls across all levels to prevent overload.
+
+        This test creates a deep pipeline that would require more than MAX_FETCHES
+        API calls if unbounded, and verifies the traversal stops at the limit.
+        """
+        # Create a linear chain of datasets/jobs that exceeds MAX_FETCHES
+        # Each step: dataset -> job -> dataset -> job -> ...
+        # We need MAX_FETCHES + 10 entities to ensure we hit the limit
+        num_datasets = MAX_FETCHES + 10
+        num_jobs = num_datasets - 1
+
+        datasets = {}
+        jobs = {}
+
+        # Create linear chain: d0 -> j0 -> d1 -> j1 -> d2 -> ...
+        for i in range(num_datasets):
+            datasets[f"d{i}"] = {
+                "id": f"d{i}",
+                "uuid": f"uuid-{i}",
+                "name": f"Dataset {i}",
+                "creating_job": f"j{i-1}" if i > 0 else None,
+            }
+
+        for i in range(num_jobs):
+            jobs[f"j{i}"] = {
+                "id": f"j{i}",
+                "tool_id": "tool",
+                "inputs": {f"input": {"id": f"d{i}", "uuid": f"uuid-{i}"}},
+                "outputs": {f"output": {"id": f"d{i+1}", "uuid": f"uuid-{i+1}"}},
+            }
+
+        pipeline_data = {"datasets": datasets, "jobs": jobs}
+
+        # Track API calls
+        api_call_count = 0
+
+        async def counting_mock_api(ctx, spec):
+            nonlocal api_call_count
+            api_call_count += 1
+
+            target = spec.get("target", "")
+            input_data = spec.get("input", {})
+
+            if "datasets" in target:
+                dataset_id = input_data.get("dataset_id")
+                if dataset_id in pipeline_data["datasets"]:
+                    return {"ok": True, "result": pipeline_data["datasets"][dataset_id]}
+                return {"ok": False, "error": {"message": f"Dataset not found: {dataset_id}"}}
+
+            if "jobs" in target:
+                job_id = input_data.get("job_id")
+                if job_id in pipeline_data["jobs"]:
+                    return {"ok": True, "result": pipeline_data["jobs"][job_id]}
+                return {"ok": False, "error": {"message": f"Job not found: {job_id}"}}
+
+            return {"ok": False, "error": {"message": f"Unknown target: {target}"}}
+
+        mock_registry.call_api = counting_mock_api
+
+        # Start from the last dataset to traverse the whole chain
+        last_dataset_id = f"d{num_datasets - 1}"
+
+        traverse_node = {
+            "type": "traverse",
+            "seed": {"$ref": "state.source_dataset"},
+            "seed_type": "dataset",
+            "max_depth": 100,  # High depth to not limit by depth
+            "max_per_level": 100,  # High per-level to not limit by level
+            "types": {
+                "dataset": {
+                    "id_field": "id",
+                    "fetch": {
+                        "target": "galaxy.datasets.show.get",
+                        "id_param": "dataset_id",
+                    },
+                    "relations": {
+                        "creating_job": {"type": "job", "extract": "creating_job"},
+                    },
+                },
+                "job": {
+                    "id_field": "id",
+                    "fetch": {
+                        "target": "galaxy.jobs.show.get",
+                        "id_param": "job_id",
+                    },
+                    "relations": {
+                        "inputs": {"type": "dataset", "extract": "inputs.*.id"},
+                    },
+                },
+            },
+        }
+
+        ctx = {
+            "state": {"source_dataset": pipeline_data["datasets"][last_dataset_id]},
+            "inputs": {},
+        }
+
+        result = await handler.execute(traverse_node, ctx, mock_registry, mock_runner)
+
+        assert result["ok"] is True
+
+        # Verify API calls were limited by MAX_FETCHES
+        assert api_call_count <= MAX_FETCHES, (
+            f"API calls ({api_call_count}) should not exceed MAX_FETCHES ({MAX_FETCHES})"
+        )
+
+        # Verify we actually hit the limit (not just finishing early)
+        assert api_call_count == MAX_FETCHES, (
+            f"Should have made exactly MAX_FETCHES ({MAX_FETCHES}) API calls, made {api_call_count}"
+        )

--- a/packages/polaris/polaris_dataset_report/polaris_dataset_report/agent.yml
+++ b/packages/polaris/polaris_dataset_report/polaris_dataset_report/agent.yml
@@ -95,6 +95,8 @@ nodes:
         $ref: result.dataset
       state.job_details:
         $ref: result.job
+      state.truncated:
+        $ref: truncated
     next: fetch_citations
 
   # Step 4: Fetch citations for tools used
@@ -213,6 +215,8 @@ nodes:
           from:
             $ref: state.job_details
           fields: [id, tool_id, inputs, outputs, create_time]
+      truncated:
+        $ref: state.truncated
       workflow_analysis:
         $ref: state.workflow_analysis
       report:

--- a/packages/polaris/public/polaris.xml
+++ b/packages/polaris/public/polaris.xml
@@ -26,8 +26,6 @@ Exclude internal Galaxy tools starting with "__" (like __DATA_FETCH__, __SET_MET
 Only describe tools that actually appear in the provided data - do not hallucinate.
         ]]></ai_prompt>
         <ai_max_tokens>4096</ai_max_tokens>
-        <depth>5</depth>
-        <max_per_level>5</max_per_level>
     </specs>
     <help format="markdown"><![CDATA[
 # What is Polaris

--- a/packages/polaris/public/polaris.xml
+++ b/packages/polaris/public/polaris.xml
@@ -26,8 +26,8 @@ Exclude internal Galaxy tools starting with "__" (like __DATA_FETCH__, __SET_MET
 Only describe tools that actually appear in the provided data - do not hallucinate.
         ]]></ai_prompt>
         <ai_max_tokens>4096</ai_max_tokens>
-        <depth>10</depth>
-        <max_per_level>10</max_per_level>
+        <depth>5</depth>
+        <max_per_level>5</max_per_level>
     </specs>
     <help format="markdown"><![CDATA[
 # What is Polaris

--- a/packages/polaris/src/components/Dashboard.vue
+++ b/packages/polaris/src/components/Dashboard.vue
@@ -52,11 +52,21 @@ const isLoading = computed(() => !props.data.markdownContent);
 
 // Detect jobs with missing input data (likely API permission errors)
 const apiWarnings = computed(() => {
-    const { jobDetails } = props.data;
+    const warnings: string[] = [];
+    const { jobDetails, truncated } = props.data;
+
+    // Check for truncated results
+    if (truncated) {
+        warnings.push("Results were truncated due to traversal limits. The full provenance may not be shown.");
+    }
+
+    // Check for missing job inputs
     const missingJobs = jobDetails.filter((j) => !j.tool_id.startsWith("__") && !j.inputs).map((j) => j.tool_id);
-    return missingJobs.length > 0
-        ? [`Failed to fetch inputs for ${missingJobs.length} job(s): ${missingJobs.join(", ")}`]
-        : [];
+    if (missingJobs.length > 0) {
+        warnings.push(`Failed to fetch inputs for ${missingJobs.length} job(s): ${missingJobs.join(", ")}`);
+    }
+
+    return warnings;
 });
 </script>
 

--- a/packages/polaris/src/types.ts
+++ b/packages/polaris/src/types.ts
@@ -63,6 +63,7 @@ export interface ReportDataType {
     markdownContent: string;
     mermaidDiagram: string;
     sourceDatasetId?: string;
+    truncated?: boolean;
 }
 
 export type Json = null | boolean | number | string | Json[] | { [k: string]: Json };


### PR DESCRIPTION
This change introduces a hard cap of **25** Galaxy API fetch requests during Polaris traversal to further bound request volume and ensure predictable behavior on public instances. The cap is enforced regardless of depth or branching configuration and complements existing safeguards such as fixed traversal limits, request delays, and deduplication. The goal is to keep the visualization strictly read-only, conservative in resource usage, and aligned with operational expectations.