### PR TITLE
update openlayers

### DIFF
--- a/packages/openlayers/package.json
+++ b/packages/openlayers/package.json
@@ -18,7 +18,7 @@
         "file-saver": "^2.0.5",
         "galaxy-charts": "^0.0.73",
         "galaxy-charts-xml-parser": "^1.0.3",
-        "ol": "^10.2.1",
+        "ol": "^10.8.0",
         "postcss": "^8.4.40",
         "prettier": "^3.3.3",
         "shpjs": "^6.1.0",


### PR DESCRIPTION
fixes: https://github.com/galaxyproject/galaxy-visualizations/issues/155

The current version seems to have problems.

https://support.tmssoftware.com/t/osm-access-blocked-referer-error-affecting-openlayers-and-leaflet/26792/8

@guerler is that all what is needed?