### PR TITLE
Change default geometry type from 'Circle' to 'None'

### DIFF
--- a/packages/openlayers/package.json
+++ b/packages/openlayers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@galaxyproject/openlayers",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "type": "module",
     "license": "MIT",
     "scripts": {

--- a/packages/openlayers/public/openlayers.xml
+++ b/packages/openlayers/public/openlayers.xml
@@ -25,7 +25,7 @@
             <help>Select a geometry type.</help>
             <type>select</type>
             <display>radio</display>
-            <value>Circle</value>
+            <value>None</value>
             <data>
                 <data>
                     <label>None</label>


### PR DESCRIPTION
Requested here: https://github.com/galaxyproject/galaxy-visualizations/issues/158